### PR TITLE
Set site-checker as default active tool on tools page

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1905,7 +1905,7 @@
 						</p>
 
 						<div class="tools-grid">
-							<div class="tool-card" data-tool="site-checker">
+							<div class="tool-card active" data-tool="site-checker">
 								<div class="tool-icon">
 									<svg
 										viewBox="0 0 24 24"
@@ -1980,7 +1980,7 @@
 								<span class="tool-label">Referrer Control</span>
 							</div>
 
-							<div class="tool-card active" data-tool="cloaker">
+							<div class="tool-card" data-tool="cloaker">
 								<div class="tool-icon">
 									<svg
 										viewBox="0 0 24 24"
@@ -2029,7 +2029,7 @@
 						<!-- Tool Interfaces -->
 						<div class="tool-interfaces">
 							<!-- Site Checker -->
-							<div id="site-checker-interface" class="tool-interface">
+							<div id="site-checker-interface" class="tool-interface active">
 								<h3 class="tool-interface-title">
 									<svg
 										viewBox="0 0 24 24"
@@ -2262,7 +2262,7 @@
 							</div>
 
 							<!-- Cloaker -->
-							<div id="cloaker-interface" class="tool-interface active">
+							<div id="cloaker-interface" class="tool-interface">
 								<h3 class="tool-interface-title">
 									<svg
 										viewBox="0 0 24 24"


### PR DESCRIPTION
## Purpose
The user requested that when navigating to the tools page, users should start on the first tool by default to improve the initial user experience and provide a clear starting point.

## Code changes
- Moved the `active` class from the "cloaker" tool card to the "site-checker" tool card (first tool in the grid)
- Updated the corresponding tool interfaces to show the site-checker interface as active by default instead of the cloaker interface
- This ensures the first tool (site-checker) is selected and displayed when users first visit the tools page

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 15`

🔗 [Edit in Builder.io](https://builder.io/app/projects/20a1ca2eaaae4790a8b4efca32e8493d/curry-works)

👀 [Preview Link](https://20a1ca2eaaae4790a8b4efca32e8493d-curry-works.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>20a1ca2eaaae4790a8b4efca32e8493d</projectId>-->
<!--<branchName>curry-works</branchName>-->